### PR TITLE
Small bug fix on interactive 

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def interactive(model_path: str, max_tokens: int = 35, temperature: float = 0.7)
 
     while True:
         prompt = input("Prompt: ")
-        res, _logprobs = generate([prompt], transformer, tokenizer, max_tokens)
+        res, _logprobs = generate([prompt], transformer, tokenizer, max_tokens=max_tokens)
         print(res[0])
         print("=====================")
 


### PR DESCRIPTION
Fixes the following bug I get when running interactive:

```
/content/mistral-src# python -m main interactive /content/mistral-7B-v0.1
Prompt: How many people live in South korea?
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/content/mistral-src/main.py", line 134, in <module>
    fire.Fire({
  File "/usr/local/lib/python3.10/dist-packages/fire/core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/usr/local/lib/python3.10/dist-packages/fire/core.py", line 475, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/usr/local/lib/python3.10/dist-packages/fire/core.py", line 691, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/content/mistral-src/main.py", line 110, in interactive
    res, _logprobs = generate([prompt], transformer, tokenizer, max_tokens)
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
TypeError: generate() takes 3 positional arguments but 4 were given
```