### PR TITLE
Update PyTorch to 2.2.0 to support NVIDIA H100 PCIe

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && \
 ENV TORCH_CUDA_ARCH_LIST "7.0;7.2;7.5;8.0;8.6;8.9;9.0"
 
 # We have to manually install Torch otherwise apex & xformers won't build
-RUN pip3 install torch==2.2.0.dev20231013+cu118 --index-url https://download.pytorch.org/whl/nightly/cu118
+RUN pip3 install "torch==2.2.0.dev20231013+cu118" --index-url https://download.pytorch.org/whl/nightly/cu118
 
 # This build is slow but NVIDIA does not provide binaries. Increase MAX_JOBS as needed.
 RUN git clone https://github.com/NVIDIA/apex && \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,7 +14,9 @@ RUN apt update && \
 ENV TORCH_CUDA_ARCH_LIST "7.0;7.2;7.5;8.0;8.6;8.9;9.0"
 
 # We have to manually install Torch otherwise apex & xformers won't build
-RUN pip3 install "torch==2.2.0.dev20231013+cu118" --index-url https://download.pytorch.org/whl/nightly/cu118
+RUN pip3 install "torch>=2.0.0"
+# To enable H100 PCIe support, install PyTorch >=2.2.0 by uncommenting the following line
+# RUN pip3 install "torch==2.2.0.dev20231018+cu118" --index-url https://download.pytorch.org/whl/nightly/cu118
 
 # This build is slow but NVIDIA does not provide binaries. Increase MAX_JOBS as needed.
 RUN git clone https://github.com/NVIDIA/apex && \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && \
 ENV TORCH_CUDA_ARCH_LIST "7.0;7.2;7.5;8.0;8.6;8.9;9.0"
 
 # We have to manually install Torch otherwise apex & xformers won't build
-RUN pip3 install "torch>=2.0.0"
+RUN pip3 install torch==2.2.0.dev20231013+cu118 --index-url https://download.pytorch.org/whl/nightly/cu118
 
 # This build is slow but NVIDIA does not provide binaries. Increase MAX_JOBS as needed.
 RUN git clone https://github.com/NVIDIA/apex && \


### PR DESCRIPTION
Running the current version's image will give the following error on NVIDIA H100 PCIe GPUs:
```
NVIDIA H100 PCIe with CUDA capability sm_90 is not compatible with the current PyTorch installation.
The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_70 sm_75 sm_80 sm_86.
If you want to use the NVIDIA H100 PCIe GPU with PyTorch, please check the instructions at https://pytorch.org/get-started/locally/
```

Updating PyTorch to 2.2.0 (which is the in-dev version) works.