### PR TITLE
Fix Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && \
 ENV TORCH_CUDA_ARCH_LIST "7.0;7.2;7.5;8.0;8.6;8.9;9.0"
 
 # We have to manually install Torch otherwise apex & xformers won't build
-RUN pip3 install "torch>=2.0.0"
+RUN pip3 install "torch==2.1.0"
 # To enable H100 PCIe support, install PyTorch >=2.2.0 by uncommenting the following line
 # RUN pip3 install "torch==2.2.0.dev20231018+cu118" --index-url https://download.pytorch.org/whl/nightly/cu118
 


### PR DESCRIPTION
Latest PyTorch version is built with CUDA 12.1

Pin the version to the previous stable release built with CUDA 11.8